### PR TITLE
Fixed error due to variable sharing in dense layers (TF 1.2)

### DIFF
--- a/dmn_plus.py
+++ b/dmn_plus.py
@@ -192,15 +192,15 @@ class DMN_PLUS(object):
 
             feature_vec = tf.concat(features, 1)
 
-            attention = tf.layers.dense(feature_vec,
-                    self.config.embed_size,
-                    activation=tf.nn.tanh,
-                    reuse=reuse)
-
-            attention = tf.layers.dense(attention,
-                    1,
-                    activation=None,
-                    reuse=reuse)
+            attention = tf.contrib.layers.fully_connected(feature_vec,
+                            self.config.embed_size,
+                            activation_fn=tf.nn.tanh,
+                            reuse=reuse, scope="fc1")
+        
+            attention = tf.contrib.layers.fully_connected(attention,
+                            1,
+                            activation_fn=None,
+                            reuse=reuse, scope="fc2")
             
         return attention
 


### PR DESCRIPTION
Replace with fully_connected layer and proper scoping (get_attention-L195:203). Changes below
From:
```
            attention = tf.layers.dense(feature_vec,
                    self.config.embed_size,
                    activation=tf.nn.tanh,
                    reuse=reuse)

            attention = tf.layers.dense(attention,
                    1,
                    activation=None,
                    reuse=reuse)
```
To:

```
         attention = tf.contrib.layers.fully_connected(feature_vec,
                            self.config.embed_size,
                            activation_fn=tf.nn.tanh,
                            reuse=reuse, scope="fc1")
        
          attention = tf.contrib.layers.fully_connected(attention,
                            1,
                            activation_fn=None,
                            reuse=reuse, scope="fc2")
```
